### PR TITLE
ref: added ModName Layer to the release zip

### DIFF
--- a/KCDAutoPacker/ReleaseCreator.cs
+++ b/KCDAutoPacker/ReleaseCreator.cs
@@ -112,7 +112,8 @@ public class ReleaseCreator
         {
             foreach (var kv in diskFiles)
             {
-                zip.CreateEntryFromFile(kv.Value.FullName, kv.Key, CompressionLevel.Optimal);
+                String entryPath = Path.Combine(modName, kv.Key);
+                zip.CreateEntryFromFile(kv.Value.FullName, entryPath, CompressionLevel.Optimal);
                 Console.WriteLine($"\tAdded: {kv.Key}");
             }
         }


### PR DESCRIPTION
After the latest refactor. The release functionality does not add ModName folder under the zip file which forces users to create the folder themselves and that defeats the whole purpose of automatic release creation.

Old structure:
ModName-DateTimeStamp.zip
├─ mod.manifest
├─ Data/
└─ Localization/

New structure:
ModName-DateTimeStamp.zip
└─ ModName/
├─ mod.manifest
├─ Data/
└─ Localization/

Test Build: [v2025.03.09-Test](https://github.com/Umpriel/KCDAutoPacker/releases/tag/v2025.03.09-Test)